### PR TITLE
Fix attribute name of the argument

### DIFF
--- a/csshi
+++ b/csshi
@@ -125,7 +125,7 @@ def args_to_ssh_strings(args):
         hostname = None
         port = None
         if args.username:
-            debug(f'Setting default user {args.user}')
+            debug(f'Setting default user {args.username}')
             user = args.username
         if args.port:
             debug(f'Setting default port {args.port}')


### PR DESCRIPTION
# Changes
Fixes attribute name of the argument used in debug message.

Fixes following error when `--username/-l` argument is specified:
```
Traceback (most recent call last):
  File "/Users/user/.local/bin/csshi", line 230, in <module>
    ssh_strings = args_to_ssh_strings(args)
  File "/Users/user/.local/bin/csshi", line 128, in args_to_ssh_strings
    debug(f'Setting default user {args.user}')
AttributeError: 'Namespace' object has no attribute 'user'
```